### PR TITLE
Add `version` config option to `icmaa-cms` Storyblok module

### DIFF
--- a/src/modules/icmaa-cms/README.md
+++ b/src/modules/icmaa-cms/README.md
@@ -21,6 +21,7 @@ This API extension get data from headless cms of choice.
        "storyblok": {
          "spaceId": "XXXXX",
          "accessToken": "XXXXXXXXXXXXXXXXXXXXXXXX",
+         "version": "draft", // Optional: published | draft"
          "defaultLanguageCodes": [ "default", "en" ],
          "pluginFieldMap": [
           { "key": "icmaa-single-option", "values": [ "selected" ] },

--- a/src/modules/icmaa-cms/api/index.ts
+++ b/src/modules/icmaa-cms/api/index.ts
@@ -13,7 +13,7 @@ export default ({ config }: ExtensionAPIFunctionParameter): Router => {
 
   api.get('/by-uid', async (req, res) => {
     const { url, query } = req
-    const { type, uid, lang, key } = query
+    const { type, uid, lang, key, release } = query
     if (type === undefined || uid === undefined) {
       return apiStatus(res, '"uid" and "type" are mandatory in request url', 500)
     }
@@ -32,7 +32,9 @@ export default ({ config }: ExtensionAPIFunctionParameter): Router => {
     const serviceName = config.get<string>('extensions.icmaaCms.service');
     switch (serviceName) {
       case 'storyblok':
-        await storyblokConnector.fetch({ type, uid, lang, key })
+        await storyblokConnector
+          .setRelease(release as string)
+          .fetch({ type, uid, lang, key })
           .then(async response => {
             await cacheResult(config, response, reqHash, cacheTags)
             return apiStatus(res, response, 200)
@@ -46,7 +48,7 @@ export default ({ config }: ExtensionAPIFunctionParameter): Router => {
 
   api.get('/search', async (req, res) => {
     const { url, query } = req
-    const { type, q, lang, fields, page, size, sort } = query
+    const { type, q, lang, fields, page, size, sort, release } = query
     if (type === undefined || q === undefined) {
       return apiStatus(res, '"q" and "type" are mandatory in request url', 500)
     }
@@ -65,7 +67,9 @@ export default ({ config }: ExtensionAPIFunctionParameter): Router => {
     const serviceName = config.get<string>('extensions.icmaaCms.service');
     switch (serviceName) {
       case 'storyblok':
-        await storyblokConnector.search({ type, q, lang, fields, page, size, sort })
+        await storyblokConnector
+          .setRelease(release as string)
+          .search({ type, q, lang, fields, page, size, sort })
           .then(async response => {
             await cacheResult(config, response, reqHash, cacheTags)
             return apiStatus(res, response, 200)

--- a/src/modules/icmaa-cms/connector/storyblok.ts
+++ b/src/modules/icmaa-cms/connector/storyblok.ts
@@ -16,7 +16,8 @@ interface CreateAttributeOptionArrayParams {
 }
 
 class StoryblokConnector {
-  protected lang
+  protected lang: string|boolean
+  protected release: string
   protected loadAllItems: boolean
 
   public api () {
@@ -35,6 +36,10 @@ class StoryblokConnector {
           if (version) {
             merge(defaults, { version })
           }
+        }
+
+        if (this.release) {
+          merge(defaults, { from_release: this.release })
         }
 
         const querystring: string = '?' + qs.stringify(
@@ -85,6 +90,11 @@ class StoryblokConnector {
     lang = lang && !defaultLanguageCodes.includes(lang) ? lang.toLowerCase() : false
     this.lang = lang && config.get('icmaa.mandant') ? `${config.get('icmaa.mandant')}_${lang}` : lang
     return this.lang
+  }
+
+  public setRelease (release?: string) {
+    this.release = release
+    return this
   }
 
   public isJsonString (string) {

--- a/src/modules/icmaa-cms/connector/storyblok.ts
+++ b/src/modules/icmaa-cms/connector/storyblok.ts
@@ -30,6 +30,13 @@ class StoryblokConnector {
           cv: cv || await this.api().cv()
         }
 
+        if (config.has('extensions.icmaaCms.storyblok.version')) {
+          const version = config.get<'published'|'draft'>('extensions.icmaaCms.storyblok.version')
+          if (version) {
+            merge(defaults, { version })
+          }
+        }
+
         const querystring: string = '?' + qs.stringify(
           merge(defaults, params),
           { encodeValuesOnly: true, arrayFormat: 'brackets' }


### PR DESCRIPTION
* Add `version` config option to `icmaa-cms` Storyblok module to retrieve `draft` items on `test`, `stage` and `dev` systems (If we do so, its important to use a specific `preview` auth-token from Storyblok)
* Add `release` query-parameter to return the content of specific releases from Storyblok