### PR TITLE
Add datapump to ElasticSearch for `icmaa-cms` content

### DIFF
--- a/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/OrNorNullFilter.ts
+++ b/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/OrNorNullFilter.ts
@@ -1,0 +1,27 @@
+import { FilterInterface } from 'storefront-query-builder'
+
+const filter: FilterInterface = {
+  priority: 1,
+  check: ({ operator }) => ['orNull', 'norNull'].includes(operator),
+  filter: ({ value, attribute, queryChain, operator }) => queryChain
+    .filter('bool', subQuery => {
+      subQuery
+        .filterMinimumShouldMatch(1, true)
+        .orFilter('bool', b => b.notFilter('exists', attribute))
+
+      if (value.length > 0) {
+        if (operator === 'norNull') {
+          subQuery.orFilter('bool', c => {
+            return c.notFilter('terms', attribute, value)
+          })
+        } else {
+          subQuery.orFilter('terms', attribute, value)
+        }
+      }
+
+      return subQuery
+    }),
+  mutator: (value) => value[Object.keys(value)[0]]
+}
+
+export default filter

--- a/src/modules/icmaa-cms/README.md
+++ b/src/modules/icmaa-cms/README.md
@@ -48,3 +48,20 @@ This API extension get data from headless cms of choice.
 /api/ext/icmaa-cms/search?type=block&lang=de-de&q={"identifier":%20{"in":%20"navigation-meta,navigation-main"}}
 /api/icmaa-cms/search?type=block&lang=de-de&q={"identifier":%20{"in":%20"navigation-meta,navigation-main"}}
 ```
+
+## Scripts
+
+### `datapump teaser -l de`
+
+This script does pump all data of a specific content-type from Storyblok into an ElasticSearch index.
+
+It fetches the data like it would be fetched by the `/search` endpoint and formats it so the data-format is the same as we fetch it from the ES.
+
+The Storyblok query-language is pretty limited so this would be able to make more complex queries against CMS data.
+
+```bash
+# From workspace root:
+yarn workspace icmaa-cms datapump import teaser -l de
+# From module directory
+yarn datapump import teaser -l de
+```

--- a/src/modules/icmaa-cms/connector/storyblok.ts
+++ b/src/modules/icmaa-cms/connector/storyblok.ts
@@ -124,10 +124,21 @@ class StoryblokConnector {
   public async fetch ({ type, uid, lang, key }) {
     let request: Promise<any>
     const fetchById = (key && key === 'id')
+    const fetchByUuid = (key && key === 'uuid')
 
     this.matchLanguage(lang)
 
-    if (!fetchById) {
+    if (fetchById) {
+      request = this.api().get(
+        `cdn/stories/${uid}`,
+        { language: this.lang ? this.lang : undefined }
+      )
+    } else if (fetchByUuid) {
+      request = this.api().get(
+        'cdn/stories',
+        { by_uuids: uid, language: this.lang ? this.lang : undefined }
+      )
+    } else {
       let query: any = { [this.getKey(key)]: { in: uid } }
       if (key && key.startsWith('i18n_')) {
         query = {
@@ -146,11 +157,6 @@ class StoryblokConnector {
           ...query
         }
       })
-    } else {
-      request = this.api().get(
-        `cdn/stories/${uid}`,
-        { language: this.lang ? this.lang : undefined }
-      )
     }
 
     return request

--- a/src/modules/icmaa-cms/elasticsearch/elastic.schema.teaser.json
+++ b/src/modules/icmaa-cms/elasticsearch/elastic.schema.teaser.json
@@ -1,0 +1,17 @@
+{
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "attribute_id": {
+            "type": "integer"
+        },
+        "options": {
+            "properties": {
+                "value": {
+                    "type": "text"
+                }
+            }
+        }
+    }
+}

--- a/src/modules/icmaa-cms/elasticsearch/elastic.schema.teaser.json
+++ b/src/modules/icmaa-cms/elasticsearch/elastic.schema.teaser.json
@@ -1,17 +1,52 @@
 {
-    "properties": {
-        "id": {
-            "type": "integer"
-        },
-        "attribute_id": {
-            "type": "integer"
-        },
-        "options": {
-            "properties": {
-                "value": {
-                    "type": "text"
-                }
-            }
+  "properties": {
+    "storyId": {
+      "type": "integer"
+    },
+    "uid": {
+      "type": "text"
+    },
+    "uuid": {
+      "type": "text"
+    },
+    "uname": {
+      "type": "text"
+    },
+    "component": {
+      "type": "text"
+    },
+    "showFrom": {
+      "type": "date",
+      "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd"
+    },
+    "showTo": {
+      "type": "date",
+      "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd"
+    },
+    "createdAt": {
+      "type": "date",
+      "format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd"
+    },
+    "publishedAt": {
+      "type": "date",
+      "format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd"
+    },
+    "firstPublishedAt": {
+      "type": "date",
+      "format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd"
+    },
+    "order": {
+      "type": "integer"
+    },
+    "gender": {
+      "type": "text"
+    },
+    "tags": {
+      "properties": {
+        "value": {
+          "type": "text"
         }
+      }
     }
+  }
 }

--- a/src/modules/icmaa-cms/elasticsearch/elastic.schema.teaser.json
+++ b/src/modules/icmaa-cms/elasticsearch/elastic.schema.teaser.json
@@ -17,11 +17,11 @@
     },
     "showFrom": {
       "type": "date",
-      "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd"
+      "format": "yyyy-MM-dd HH:mm||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd"
     },
     "showTo": {
       "type": "date",
-      "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd"
+      "format": "yyyy-MM-dd HH:mm||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd"
     },
     "createdAt": {
       "type": "date",

--- a/src/modules/icmaa-cms/elasticsearch/elastic.schema.teaser.json
+++ b/src/modules/icmaa-cms/elasticsearch/elastic.schema.teaser.json
@@ -39,7 +39,8 @@
       "type": "integer"
     },
     "gender": {
-      "type": "text"
+      "type": "keyword",
+      "null_value": "NULL"
     },
     "tags": {
       "properties": {

--- a/src/modules/icmaa-cms/package.json
+++ b/src/modules/icmaa-cms/package.json
@@ -11,8 +11,12 @@
     "**/*.js",
     "*.js"
   ],
+  "scripts": {
+    "datapump": "export NODE_CONFIG_DIR='../../../config' && ts-node scripts/datapump.ts"
+  },
   "dependencies": {
     "@types/qs": "^6.9.1",
+    "commander": "^6.2.1",
     "marked": "^1.1.1",
     "node-fetch": "^2.6.0",
     "qs": "^6.9.1",

--- a/src/modules/icmaa-cms/scripts/datapump.ts
+++ b/src/modules/icmaa-cms/scripts/datapump.ts
@@ -1,6 +1,20 @@
 import program from 'commander'
+import path from 'path'
+
+import config from 'config'
 import storyblokConnector from 'icmaa-cms/connector/storyblok'
-import { getClient } from '@storefront-api/lib/elastic'
+import Logger from '@storefront-api/lib/logger'
+import * as es from '@storefront-api/lib/elastic'
+import { getCurrentStoreView } from '@storefront-api/lib/util'
+
+const db = es.getClient(config)
+
+const fetchItemsFromStoryblok = ({ type, lang, release }): Promise<any[]> => {
+  return storyblokConnector
+    .setRelease(release)
+    .search({ type, q: {}, lang, fields: undefined, page: undefined, size: undefined, sort: undefined })
+    .then(resp => resp)
+}
 
 program
   .command('import <type>')
@@ -8,17 +22,40 @@ program
   .option('-l, --language [lang]', 'Language for the import', 'de')
   .option('-r, --release [release]', 'Storyblok release-id to use for import')
   .action(async (type, options) => {
-    const teaser = await storyblokConnector
-      .setRelease(options.release)
-      .search({
-        type,
-        q: {},
-        lang: options.language,
-        fields: undefined,
-        page: undefined,
-        size: 5,
-        sort: undefined
-      }).then(resp => resp)
+    const { language: lang, release } = options
+
+    const timestamp = Math.round(+new Date() / 1000)
+    const storeViewConfig = getCurrentStoreView(lang)
+    const indexName = storeViewConfig.elasticsearch.index
+
+    const originalIndex = indexName + '_' + type
+    const tempIndex = originalIndex + '_' + timestamp
+    const indexSchema = es.loadSchema(
+      path.join(__dirname, '../elasticsearch'),
+      type,
+      config.get('elasticsearch.apiVersion')
+    )
+
+    Logger.info(`** Create temporary index: ${tempIndex}`)
+    await db.indices.create({
+      index: tempIndex,
+      body: indexSchema
+    }).then(() => Logger.info('   Done'))
+
+    Logger.info(`** Load all "${type}" items from Storyblok for "${lang}" `)
+    const items = await fetchItemsFromStoryblok({ type, lang, release })
+    Logger.info('   Done')
+
+    Logger.info('** Write items into temporary index')
+    const body = items.map(doc => [{ index: { _index: 'vue_storefront_catalog_de_teaser_1610709457' } }, doc])
+    db.bulk({ refresh: true, body })
+      .then(resp => {
+        Logger.info('   Result: ' + resp)
+      })
+      .catch(e => {
+        Logger.info('   Error: ' + e.message)
+        console.error(e)
+      })
   })
 
 program.parse(process.argv)

--- a/src/modules/icmaa-cms/scripts/datapump.ts
+++ b/src/modules/icmaa-cms/scripts/datapump.ts
@@ -74,6 +74,7 @@ program
       .then(resp => resp.body.filter(a => a.index !== tempIndex))
       .then(oldAliases => db.indices.delete({ index: oldAliases.map(a => a.index) }))
       .then(() => Logger.info('   Done'))
+      .catch(e => Logger.info(`   Error: ${e.message}`))
   })
 
 program.parse(process.argv)

--- a/src/modules/icmaa-cms/scripts/datapump.ts
+++ b/src/modules/icmaa-cms/scripts/datapump.ts
@@ -1,0 +1,24 @@
+import program from 'commander'
+import storyblokConnector from 'icmaa-cms/connector/storyblok'
+import { getClient } from '@storefront-api/lib/elastic'
+
+program
+  .command('import <type>')
+  .description('Import a specific type of data from Storyblok into ElasticSearch')
+  .option('-l, --language [lang]', 'Language for the import', 'de')
+  .option('-r, --release [release]', 'Storyblok release-id to use for import')
+  .action(async (type, options) => {
+    const teaser = await storyblokConnector
+      .setRelease(options.release)
+      .search({
+        type,
+        q: {},
+        lang: options.language,
+        fields: undefined,
+        page: undefined,
+        size: 5,
+        sort: undefined
+      }).then(resp => resp)
+  })
+
+program.parse(process.argv)

--- a/src/modules/icmaa-cms/scripts/datapump.ts
+++ b/src/modules/icmaa-cms/scripts/datapump.ts
@@ -52,7 +52,7 @@ program
     Logger.info('** Write items into temporary index')
     await asyncForEach(chunk(items, chunkSize), (chunk, i) => {
       Logger.info(`   Write chunk #${i + 1}/${chunkSize}`)
-      const body = flatten(chunk.map(doc => [{ index: { _index: tempIndex } }, doc]))
+      const body = flatten(chunk.map(doc => [{ index: { _index: tempIndex, _id: doc.uid } }, doc]))
       return db.bulk({ body })
         .then(() => {
           Logger.info('     Done')

--- a/src/modules/icmaa/helpers/asyncForEach.ts
+++ b/src/modules/icmaa/helpers/asyncForEach.ts
@@ -1,0 +1,11 @@
+/**
+ * Make it possible to asynchronly load an array
+ * @see https://codeburst.io/javascript-async-await-with-foreach-b6ba62bbf404
+ * @param {Array} array
+ * @param {function} callback
+ */
+export default async function (array: any[], callback: (item, index, array) => any): Promise<void> {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5165,6 +5165,11 @@ commander@^6.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
   integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
 
+commander@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
 commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
@@ -10871,7 +10876,6 @@ macos-release@^2.2.0:
 
 "magento2-rest-client@https://github.com/DivanteLtd/magento2-rest-client":
   version "0.0.13"
-  uid "32632162060588c6f9e86eba47ad4544229307f2"
   resolved "https://github.com/DivanteLtd/magento2-rest-client#32632162060588c6f9e86eba47ad4544229307f2"
   dependencies:
     humps "^1.1.0"


### PR DESCRIPTION
* Add datapump script to import any Storyblok content-type into its own localized ElasticSearch index using `commander` and `elastic` library of the API
* Add `OrNorNullFilter` to be able to filter for a specific attribute or `null` – if you filter with the regular `or` filter you won't be able to add multiple attribute-or-null filter
* Add `asyncForEach.ts` helper for chunk-iteration of the datapump and further use
* Add fetch by `uuid` to `/icmaa-cms/by-uid` endpoint