### PR TITLE
Release 2021-03-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bugfix for loading correct resolvers files in production build - @cewald (#104)
+
 ### Changed / Improved
 - updated eslint and typescript eslint plugin to newest version to have better typescript support - @resubaka (#78)
 

--- a/packages/lib/helpers/graphql.ts
+++ b/packages/lib/helpers/graphql.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { fileLoader } from 'merge-graphql-schemas';
 
 export function loadModuleResolversArray (graphQlPath: string, extensionsPath?: string): any[] {
-  const fileLoaderExt = process.env.VS_ENV && process.env.VS_ENV === 'dev' ? 'ts' : 'js'
+  const fileLoaderExt = process.env.VS_ENV === 'dev' ? 'ts' : 'js'
   const rootResolvers = fileLoader(path.join(graphQlPath, `*.resolver.${fileLoaderExt}`))
   const coreResolvers = fileLoader(
     path.join(graphQlPath, `/**/resolver.${fileLoaderExt}`)

--- a/src/modules/icmaa-cms/helpers/formatter/storyblok.ts
+++ b/src/modules/icmaa-cms/helpers/formatter/storyblok.ts
@@ -41,7 +41,7 @@ export const extractPluginValues = async <T>(object: Record<string, any>): Promi
 
     if (/(rte|markdown)$/.test(key)) {
       object[key] = await import('marked')
-        .then(m => m.default(object[key]))
+        .then(m => m.default(object[key], { gfm: true, breaks: true }))
         .catch(e => {
           console.error('Error during Markdown parsing in value mapping:', e)
           return ''


### PR DESCRIPTION
* Add GitHub-Flavored-Markdown to `marked` parser (#27)
* Merge latest `vuestorefront/develop` (#29)