### PR TITLE
Timezone support for datetime-range-queries against the ES in `storefront-query-builder`

### DIFF
--- a/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/ActiveByDateRangeFilter.ts
+++ b/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/ActiveByDateRangeFilter.ts
@@ -3,7 +3,7 @@ import { FilterInterface } from 'storefront-query-builder'
 import moment from 'moment-timezone'
 import omit from 'lodash/omit'
 
-interface FilterDefaults { from: string, to: string, utcOffset: string }
+interface FilterDefaults { from: string, to: string, timezone?: string }
 const defaultFields = config.get<FilterDefaults>('extensions.icmaa-catalog.defaultDateRangeFields')
 
 const filter: FilterInterface = {
@@ -15,15 +15,24 @@ const filter: FilterInterface = {
       value = {}
     }
 
-    let dateTime = value.dateTime || defaultFields.utcOffset
+    let dateTime = value.dateTime || 'now'
+    const timezone = defaultFields.timezone || false
     const fromField = value.fromField || defaultFields.from
     const toField = value.toField || defaultFields.to
 
-    // Get UTC offset from timezone using the dateTime parameter.
-    // We assume that times in the ES are always saved in UTC format so we can use the offset of the timezone.
-    if (!dateTime.startsWith('now') && !moment(new Date(dateTime), moment.ISO_8601).isValid()) {
-      const tzOffset = moment.tz(dateTime).utcOffset() / 60
-      dateTime = Math.sign(tzOffset) !== -1 ? `now+${tzOffset}h` : `now${tzOffset}h`
+    // Get UTC offset or time using timezone.
+    // We assume that times in the ES are always saved in UTC – if not we can set an offset
+    // by the desired timezone or format the transmitted UTC date into the target timezone.
+    if (timezone) {
+      const isValidDateTime = moment(new Date(dateTime), moment.ISO_8601).isValid()
+      if (dateTime === 'now') {
+        const tzOffset = moment.tz(timezone).utcOffset() / 60
+        dateTime = Math.sign(tzOffset) !== -1 ? `now+${tzOffset}h` : `now${tzOffset}h`
+      } else if (isValidDateTime) {
+        dateTime = isValidDateTime
+          ? moment.tz(dateTime, timezone).format('yyyy-MM-DD HH:mm:ss')
+          : moment.tz(timezone).format('yyyy-MM-DD HH:mm:ss')
+      }
     }
 
     value = omit(value, ['dateTime', 'fromField', 'toField'])

--- a/src/modules/icmaa/package.json
+++ b/src/modules/icmaa/package.json
@@ -14,9 +14,11 @@
   "dependencies": {
     "axios": "^0.19.0",
     "ioredis": "^4.27.2",
+    "moment-timezone": "^0.5.33",
     "redis-tag-cache": "^1.2.1"
   },
   "devDependencies": {
-    "@types/ioredis": "^4.26.1"
+    "@types/ioredis": "^4.26.1",
+    "@types/moment-timezone": "^0.5.30"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2679,6 +2679,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
+"@types/moment-timezone@^0.5.30":
+  version "0.5.30"
+  resolved "https://registry.yarnpkg.com/@types/moment-timezone/-/moment-timezone-0.5.30.tgz#340ed45fe3e715f4a011f5cfceb7cb52aad46fc7"
+  integrity sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==
+  dependencies:
+    moment-timezone "*"
+
 "@types/node-fetch@2.5.7":
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
@@ -11610,6 +11617,13 @@ module-details-from-path@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
+
+moment-timezone@*, moment-timezone@^0.5.33:
+  version "0.5.33"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
+  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
+  dependencies:
+    moment ">= 2.9.0"
 
 moment-timezone@^0.5.x:
   version "0.5.32"


### PR DESCRIPTION
* We now can enter a valid timezone in the configs or directly in the query and won't need to rely on switching offsets when summer-/winter-time changes
* See `timezone` config in `extensions.icmaa-catalog.defaultDateRangeFields` – we can set this now to `Europe/Berlin` and always have the correct offset

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
