### PR TITLE
#225953 Load custom-filter `/_ah/warmup` request

### DIFF
--- a/src/modules/icmaa/index.ts
+++ b/src/modules/icmaa/index.ts
@@ -1,7 +1,8 @@
+import * as path from 'path'
 import { StorefrontApiModule, registerExtensions } from '@storefront-api/lib/module'
 import { StorefrontApiContext } from '@storefront-api/lib/module/types'
 import invalidate from './invalidate'
-import * as path from 'path'
+import warmup from './warmup'
 
 export const IcmaaModule: StorefrontApiModule = new StorefrontApiModule({
   key: 'icmaa-module',
@@ -12,6 +13,6 @@ export const IcmaaModule: StorefrontApiModule = new StorefrontApiModule({
     registerExtensions({ app, config, db, registeredExtensions, rootPath })
 
     app.get('/api/invalidate/all', invalidate)
-    app.get('/_ah/warmup', (req, res) => res.send('Warm-Up for storefront-api'))
+    app.get('/_ah/warmup', warmup)
   }
 })

--- a/src/modules/icmaa/warmup.ts
+++ b/src/modules/icmaa/warmup.ts
@@ -1,0 +1,16 @@
+import config from 'config'
+import { RequestHandler } from 'express'
+import loadCustomFilters from '@storefront-api/default-catalog/helper/loadCustomFilters'
+
+const router: RequestHandler = async (req, res) => {
+  /**
+   * Load the custom-filters because this takes some time, the first time.
+   * Otherwise this might cause random delays in API request each time a new node is started.
+   */
+  await loadCustomFilters(config)
+  await loadCustomFilters(config, 'product')
+
+  res.send('Warm-Up for storefront-api done')
+}
+
+export default router


### PR DESCRIPTION
* The first call of each catalog-request takes up to 7s because the custom filters for the `storefront-query-builder` are initialized
* We now load them inside the GAE warm-up route so the first real request should be fast
* This might have caused random slow queries against the API each time a new node is spinned up and requested first

## Related ticket
<!--  Put related Redmin issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-225953

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
