### PR TITLE
#234147 Add `icmaa-paypal` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "humps": "^1.1.0",
     "icmaa": "*",
     "icmaa-checkout": "*",
+    "icmaa-paypal": "*",
     "icmaa-cms": "*",
     "icmaa-competitions": "*",
     "icmaa-facebook": "*",

--- a/src/modules/icmaa-checkout/README.md
+++ b/src/modules/icmaa-checkout/README.md
@@ -9,19 +9,20 @@ This API extension gets extendend checkout & quote information from a custom `vs
 2. Add the new endpoint to the VSF in `local.json` to:
    ```
    "icmaa_checkout": {
+     "endpoint": "/api/icmaa-checkout",
      "endpoints": {
-        "agreements": "/api/icmaa-checkout/agreements",
-        "quote": "/quote?token={{token}}&cartId={{cartId}}",
-        "shippingMethods": "/shipping-methods?token={{token}}&cartId={{cartId}}",
-        "order": "/order?token={{token}}&cartId={{cartId}}"
-     }
+       "quote": "/quote?token={{token}}&cartId={{cartId}}",
+       "shippingMethods": "/shipping-methods?token={{token}}&cartId={{cartId}}",
+       "order": "/order?token={{token}}&cartId={{cartId}}"
+     },
+     // ...
    },
    ```
 
 ## API endpoints
 ```
-/api/ext/icmaa-checkout/shipping-methods
-/api/ext/icmaa-checkout/quote
-/api/ext/icmaa-checkout/agreements
-/api/ext/icmaa-checkout/order
+/api/icmaa-checkout/shipping-methods
+/api/icmaa-checkout/quote
+/api/icmaa-checkout/agreements
+/api/icmaa-checkout/order
 ```

--- a/src/modules/icmaa-paypal/README.md
+++ b/src/modules/icmaa-paypal/README.md
@@ -1,0 +1,22 @@
+# ICMAA - Checkout PayPal data extension
+
+This API extension gets and sends informations for PayPal payments to the VSBrige in Magento.
+
+## Configuration
+
+1. In your `local.json` file you should register the extension like:
+   `"registeredExtensions": ["icmaa-paypal", …],`
+2. Add the new endpoint to the VSF in `local.json` to:
+   ```
+   "icmaa_paypal": {
+      "endpoint": "/api/icmaa-paypal",
+      "endpoints": {
+         "bypass_start": "/bypass_start?token={{token}}&cartId={{cartId}}"
+      }
+   },
+   ```
+
+## API endpoints
+```
+/api/icmaa-paypal/bypass_start
+```

--- a/src/modules/icmaa-paypal/README.md
+++ b/src/modules/icmaa-paypal/README.md
@@ -12,6 +12,7 @@ This API extension gets and sends informations for PayPal payments to the VSBrig
       "endpoint": "/api/icmaa-paypal",
       "endpoints": {
          "bypass_start": "/bypass_start?token={{token}}&cartId={{cartId}}"
+         "bypass_shipping": "/bypass_shipping?token={{token}}&cartId={{cartId}}"
       }
    },
    ```
@@ -19,4 +20,5 @@ This API extension gets and sends informations for PayPal payments to the VSBrig
 ## API endpoints
 ```
 /api/icmaa-paypal/bypass_start
+/api/icmaa-paypal/bypass_shipping
 ```

--- a/src/modules/icmaa-paypal/README.md
+++ b/src/modules/icmaa-paypal/README.md
@@ -14,7 +14,8 @@ This API extension gets and sends informations for PayPal payments to the VSBrig
          "checkout_start": "/checkout_start?token={{token}}&cartId={{cartId}}",
          "checkout_shipping": "/checkout_shipping?token={{token}}&cartId={{cartId}}",
          "checkout_approve": "/checkout_approve?token={{token}}&cartId={{cartId}}",
-         "checkout_capture": "/checkout_capture?token={{token}}&cartId={{cartId}}"
+         "checkout_capture": "/checkout_capture?token={{token}}&cartId={{cartId}}",
+         "checkout_fail": "/checkout_fail?token={{token}}&cartId={{cartId}}"
       }
    },
    ```
@@ -25,4 +26,5 @@ This API extension gets and sends informations for PayPal payments to the VSBrig
 /api/icmaa-paypal/checkout_shipping
 /api/icmaa-paypal/checkout_approve
 /api/icmaa-paypal/checkout_capture
+/api/icmaa-paypal/checkout_fail
 ```

--- a/src/modules/icmaa-paypal/README.md
+++ b/src/modules/icmaa-paypal/README.md
@@ -11,8 +11,10 @@ This API extension gets and sends informations for PayPal payments to the VSBrig
    "icmaa_paypal": {
       "endpoint": "/api/icmaa-paypal",
       "endpoints": {
-         "bypass_start": "/bypass_start?token={{token}}&cartId={{cartId}}"
-         "bypass_shipping": "/bypass_shipping?token={{token}}&cartId={{cartId}}"
+         "bypass_start": "/bypass_start?token={{token}}&cartId={{cartId}}",
+         "bypass_shipping": "/bypass_shipping?token={{token}}&cartId={{cartId}}",
+         "bypass_approve": "/bypass_approve?token={{token}}&cartId={{cartId}}",
+         "bypass_capture": "/bypass_capture?token={{token}}&cartId={{cartId}}"
       }
    },
    ```
@@ -21,4 +23,6 @@ This API extension gets and sends informations for PayPal payments to the VSBrig
 ```
 /api/icmaa-paypal/bypass_start
 /api/icmaa-paypal/bypass_shipping
+/api/icmaa-paypal/bypass_approve
+/api/icmaa-paypal/bypass_capture
 ```

--- a/src/modules/icmaa-paypal/README.md
+++ b/src/modules/icmaa-paypal/README.md
@@ -11,18 +11,18 @@ This API extension gets and sends informations for PayPal payments to the VSBrig
    "icmaa_paypal": {
       "endpoint": "/api/icmaa-paypal",
       "endpoints": {
-         "bypass_start": "/bypass_start?token={{token}}&cartId={{cartId}}",
-         "bypass_shipping": "/bypass_shipping?token={{token}}&cartId={{cartId}}",
-         "bypass_approve": "/bypass_approve?token={{token}}&cartId={{cartId}}",
-         "bypass_capture": "/bypass_capture?token={{token}}&cartId={{cartId}}"
+         "checkout_start": "/checkout_start?token={{token}}&cartId={{cartId}}",
+         "checkout_shipping": "/checkout_shipping?token={{token}}&cartId={{cartId}}",
+         "checkout_approve": "/checkout_approve?token={{token}}&cartId={{cartId}}",
+         "checkout_capture": "/checkout_capture?token={{token}}&cartId={{cartId}}"
       }
    },
    ```
 
 ## API endpoints
 ```
-/api/icmaa-paypal/bypass_start
-/api/icmaa-paypal/bypass_shipping
-/api/icmaa-paypal/bypass_approve
-/api/icmaa-paypal/bypass_capture
+/api/icmaa-paypal/checkout_start
+/api/icmaa-paypal/checkout_shipping
+/api/icmaa-paypal/checkout_approve
+/api/icmaa-paypal/checkout_capture
 ```

--- a/src/modules/icmaa-paypal/index.ts
+++ b/src/modules/icmaa-paypal/index.ts
@@ -32,5 +32,9 @@ module.exports = ({ config }: ExtensionAPIFunctionParameter): Router => {
     createNewClientActionProxy(req, res, 'icmaa-paypal', 'capture', 'paypal_checkout/')
   )
 
+  api.post('/checkout_fail', async (req, res) =>
+    createNewClientActionProxy(req, res, 'icmaa-paypal', 'fail', 'paypal_checkout/')
+  )
+
   return api
 }

--- a/src/modules/icmaa-paypal/index.ts
+++ b/src/modules/icmaa-paypal/index.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express'
+import { apiStatus } from '@storefront-api/lib/util'
+import { ExtensionAPIFunctionParameter } from '@storefront-api/lib/module'
+import { newMagentoClientAction } from 'icmaa/helpers'
+
+module.exports = ({ config }: ExtensionAPIFunctionParameter): Router => {
+  const api = Router()
+
+  const createNewClientActionProxy = async (req, res, moduleName, endpoint, urlPrefix) => {
+    const client = newMagentoClientAction(moduleName, endpoint, urlPrefix, config, req)
+    client[moduleName][endpoint](req.body)
+      .then((result) => {
+        apiStatus(res, result, 200)
+      }).catch(err => {
+        apiStatus(res, err, 500)
+      })
+  }
+
+  api.post('/bypass_start', async (req, res) =>
+    createNewClientActionProxy(req, res, 'icmaa-paypal', 'start', 'paypal_bypass/')
+  )
+
+  return api
+}

--- a/src/modules/icmaa-paypal/index.ts
+++ b/src/modules/icmaa-paypal/index.ts
@@ -24,5 +24,13 @@ module.exports = ({ config }: ExtensionAPIFunctionParameter): Router => {
     createNewClientActionProxy(req, res, 'icmaa-paypal', 'shipping', 'paypal_bypass/')
   )
 
+  api.post('/bypass_approve', async (req, res) =>
+    createNewClientActionProxy(req, res, 'icmaa-paypal', 'approve', 'paypal_bypass/')
+  )
+
+  api.post('/bypass_capture', async (req, res) =>
+    createNewClientActionProxy(req, res, 'icmaa-paypal', 'capture', 'paypal_bypass/')
+  )
+
   return api
 }

--- a/src/modules/icmaa-paypal/index.ts
+++ b/src/modules/icmaa-paypal/index.ts
@@ -16,20 +16,20 @@ module.exports = ({ config }: ExtensionAPIFunctionParameter): Router => {
       })
   }
 
-  api.post('/bypass_start', async (req, res) =>
-    createNewClientActionProxy(req, res, 'icmaa-paypal', 'start', 'paypal_bypass/')
+  api.post('/checkout_start', async (req, res) =>
+    createNewClientActionProxy(req, res, 'icmaa-paypal', 'start', 'paypal_checkout/')
   )
 
-  api.post('/bypass_shipping', async (req, res) =>
-    createNewClientActionProxy(req, res, 'icmaa-paypal', 'shipping', 'paypal_bypass/')
+  api.post('/checkout_shipping', async (req, res) =>
+    createNewClientActionProxy(req, res, 'icmaa-paypal', 'shipping', 'paypal_checkout/')
   )
 
-  api.post('/bypass_approve', async (req, res) =>
-    createNewClientActionProxy(req, res, 'icmaa-paypal', 'approve', 'paypal_bypass/')
+  api.post('/checkout_approve', async (req, res) =>
+    createNewClientActionProxy(req, res, 'icmaa-paypal', 'approve', 'paypal_checkout/')
   )
 
-  api.post('/bypass_capture', async (req, res) =>
-    createNewClientActionProxy(req, res, 'icmaa-paypal', 'capture', 'paypal_bypass/')
+  api.post('/checkout_capture', async (req, res) =>
+    createNewClientActionProxy(req, res, 'icmaa-paypal', 'capture', 'paypal_checkout/')
   )
 
   return api

--- a/src/modules/icmaa-paypal/index.ts
+++ b/src/modules/icmaa-paypal/index.ts
@@ -20,5 +20,9 @@ module.exports = ({ config }: ExtensionAPIFunctionParameter): Router => {
     createNewClientActionProxy(req, res, 'icmaa-paypal', 'start', 'paypal_bypass/')
   )
 
+  api.post('/bypass_shipping', async (req, res) =>
+    createNewClientActionProxy(req, res, 'icmaa-paypal', 'shipping', 'paypal_bypass/')
+  )
+
   return api
 }

--- a/src/modules/icmaa-paypal/package.json
+++ b/src/modules/icmaa-paypal/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "icmaa-paypal",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "cewald <c.ewald@impericon.com> and contributors",
+  "license": "MIT",
+  "private": true,
+  "files": [
+    "**/*.d.ts",
+    "*.d.ts",
+    "**/*.js",
+    "*.js"
+  ]
+}

--- a/src/modules/icmaa-paypal/tsconfig.json
+++ b/src/modules/icmaa-paypal/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../packages/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./"
+  },
+  "include": ["*.ts", "**/*.ts"]
+}

--- a/src/modules/tsconfig.build.json
+++ b/src/modules/tsconfig.build.json
@@ -2,6 +2,7 @@
   "references": [
     { "path": "./icmaa" },
     { "path": "./icmaa-checkout" },
+    { "path": "./icmaa-paypal" },
     { "path": "./icmaa-cms" },
     { "path": "./icmaa-competitions" },
     { "path": "./icmaa-facebook" },


### PR DESCRIPTION
Add API proxy for our custom ICMAA module.

This is connected to:
* https://github.com/icmaa/magento/pull/1239
* https://github.com/icmaa/vue-storefront/pull/684

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-234147

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
