### PR TITLE
Add `resetPasswordUsingResetToken` endpoint to `magento1-vsbridge-client`

### DIFF
--- a/src/modules/magento1-vsbridge-client/lib/user.js
+++ b/src/modules/magento1-vsbridge-client/lib/user.js
@@ -14,9 +14,16 @@ module.exports = function (restClient) {
       return getResponse(data);
     });
   }
-  module.resetPassword = function (emailData) {
+  module.resetPassword = function (data) {
     url += 'resetPassword';
-    return restClient.post(url, { email: emailData.email }).then((data) => {
+    return restClient.post(url, { email: data.email }).then((data) => {
+      return getResponse(data);
+    });
+  }
+  module.resetPasswordUsingResetToken = function (data) {
+    url += 'resetPasswordPost';
+    const { email, newPassword, resetToken } = data
+    return restClient.post(url, { email, newPassword, resetToken }).then((data) => {
       return getResponse(data);
     });
   }


### PR DESCRIPTION
This feature was missing since I included `magento1-vsbridge-client` into the monorepo.

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
