### PR TITLE
#247458 Refactor URL mapping and improve catalog-requests

### DIFF
--- a/packages/default-catalog/api/catalog.ts
+++ b/packages/default-catalog/api/catalog.ts
@@ -24,6 +24,7 @@ async function _cacheStorageHandler (config: IConfig, result: Record<string, any
       Logger.error(err)
     })
   }
+  return new Promise(resolve => resolve)
 }
 
 function _outputFormatter (responseBody: Record<string, any>, format = 'standard'): Record<string, any> {
@@ -187,7 +188,7 @@ export default ({ config }: ExtensionAPIFunctionParameter) => async function (re
 
             _resBody = _outputFormatter(_resBody, responseFormat)
 
-            _cacheStorageHandler(config, _resBody, reqHash, tagsArray)
+            await _cacheStorageHandler(config, _resBody, reqHash, tagsArray)
           }
 
           res.json(_resBody)

--- a/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
+++ b/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
@@ -1,0 +1,25 @@
+import config from 'config'
+import { FilterInterface } from 'storefront-query-builder'
+
+const searchFields: string[] = config.get('urlModule.map.searchedFields') || []
+
+const filter: FilterInterface = {
+  priority: 1,
+  check: ({ attribute }) => attribute === 'mapUrl',
+  filter: ({ value, queryChain }) => {
+    if (!value) return queryChain
+
+    searchFields.forEach(field => {
+      queryChain.orFilter('match_phrase', field, { query: value })
+    })
+
+    queryChain
+      .filterMinimumShouldMatch(1)
+      .size(1)
+
+    return queryChain
+  },
+  mutator: v => v?.in[0] || false
+}
+
+export default filter

--- a/packages/default-catalog/helper/loadCustomFilters.ts
+++ b/packages/default-catalog/helper/loadCustomFilters.ts
@@ -2,7 +2,13 @@ import path from 'path'
 import { IConfig } from 'config'
 import { FilterInterface } from 'storefront-query-builder'
 
+const allFilters: Record<string, Record<string, FilterInterface>> = {}
+
 export default async function loadModuleCustomFilters (config: IConfig, type = 'catalog'): Promise<Record<string, FilterInterface>> {
+  if (allFilters[type]) {
+    return allFilters[type]
+  }
+
   const filters: Record<string, FilterInterface> = {}
   const filterPromises: Promise<void>[] = []
 
@@ -25,5 +31,9 @@ export default async function loadModuleCustomFilters (config: IConfig, type = '
     }
   }
 
-  return Promise.all(filterPromises).then(() => filters)
+  return Promise.all(filterPromises)
+    .then(() => {
+      allFilters[type] = filters
+      return filters
+    })
 }

--- a/src/modules/icmaa/index.ts
+++ b/src/modules/icmaa/index.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 import { StorefrontApiModule, registerExtensions } from '@storefront-api/lib/module'
 import { StorefrontApiContext } from '@storefront-api/lib/module/types'
 import registerLogger from './logger'
+import url from './url'
 import invalidate from './invalidate'
 import warmup from './warmup'
 
@@ -22,6 +23,8 @@ export const IcmaaModule: StorefrontApiModule = new StorefrontApiModule({
     const rootPath = path.join(__dirname, '..')
     const registeredExtensions: string[] = config.get('modules.icmaa.registeredExtensions')
     registerExtensions({ app, config, db, registeredExtensions, rootPath })
+
+    app.use('/api/icmaa-url', url({ config, db }))
 
     app.get('/api/invalidate/all', invalidate)
     app.get('/_ah/warmup', warmup)

--- a/src/modules/icmaa/url.ts
+++ b/src/modules/icmaa/url.ts
@@ -1,10 +1,13 @@
 import { ExtensionAPIFunctionParameter } from '@storefront-api/lib/module'
-import { getClient as getElasticClient } from '@storefront-api/lib/elastic'
+import { getClient as getElasticClient, getHits } from '@storefront-api/lib/elastic'
 import { apiStatus, getCurrentStoreView, getCurrentStoreCode } from '@storefront-api/lib/util'
+import cache from '@storefront-api/lib/cache-instance'
+import Logger from '@storefront-api/lib/logger'
 import loadCustomFilters from '@storefront-api/default-catalog/helper/loadCustomFilters'
 import ProcessorFactory from '@storefront-api/default-catalog/processor/factory'
 
 import { Router } from 'express'
+import { IConfig } from 'config'
 import { elasticsearch, SearchQuery, ElasticsearchQueryConfig } from 'storefront-query-builder'
 import bodybuilder from 'bodybuilder'
 import get from 'lodash/get'
@@ -47,10 +50,45 @@ const checkFieldValueEquality = ({ config, result, value }) => {
 export default ({ config }: ExtensionAPIFunctionParameter): Router => {
   const router = Router()
 
+  async function _cacheStorageHandler (config: IConfig, result: Record<string, any>, hash: string, tags = []): Promise<void> {
+    if (config.get<boolean>('server.useOutputCache') && cache) {
+      return cache.set(
+        'api:' + hash,
+        result,
+        tags
+      ).catch((err) => {
+        Logger.error(err)
+      })
+    }
+  }
+
   router.post('/map', async (req, res) => {
+    const s = Date.now()
     const { url, excludeFields, includeFields } = req.body
     if (!url) {
       return apiStatus(res, 'Missing url', 500)
+    }
+
+    if (config.get<boolean>('server.useOutputCache') && cache) {
+      const isCached = await cache.get('api:' + url)
+        .then(output => {
+          if (output !== null) {
+            res.setHeader('x-vs-cache', 'hit')
+            Logger.debug(`Cache hit [${req.url}], cached request: ${Date.now() - s}ms`)
+            res.json(output)
+            return true
+          } else {
+            res.setHeader('x-vs-cache', 'miss')
+            Logger.debug(`Cache miss [${req.url}], request: ${Date.now() - s}ms`)
+            return false
+          }
+        })
+        .catch(err => {
+          Logger.error(err)
+          return false
+        })
+
+      if (isCached) return
     }
 
     const indexName = getCurrentStoreView(getCurrentStoreCode(req)).elasticsearch.index
@@ -65,7 +103,7 @@ export default ({ config }: ExtensionAPIFunctionParameter): Router => {
 
     try {
       const esResponse = await getElasticClient(config).search(esQuery)
-      let result = get(esResponse, 'body.hits.hits[0]', null)
+      let result = getHits(esResponse)[0]
 
       if (result && checkFieldValueEquality({ config, result, value: url })) {
         result = addResultTypeByIndexName({ result, indexName })
@@ -76,10 +114,15 @@ export default ({ config }: ExtensionAPIFunctionParameter): Router => {
           resultProcessor = factory.getAdapter('default', indexName, req, res)
         }
 
+        const tagsArray = [result._type]
+        const tagPrefix = result._type[0].toUpperCase()
+        tagsArray.push(`${tagPrefix}${result?._id}`)
+
         resultProcessor
           .process(esResponse.body.hits.hits, null)
-          .then(pResult => {
+          .then(async pResult => {
             pResult = pResult.map(h => Object.assign(h, { _score: h._score }))
+            await _cacheStorageHandler(config, pResult[0], url, tagsArray)
             return res.json(pResult[0])
           }).catch((err) => {
             console.error(err)

--- a/src/modules/icmaa/url.ts
+++ b/src/modules/icmaa/url.ts
@@ -1,0 +1,98 @@
+import { ExtensionAPIFunctionParameter } from '@storefront-api/lib/module'
+import { getClient as getElasticClient } from '@storefront-api/lib/elastic'
+import { apiStatus, getCurrentStoreView, getCurrentStoreCode } from '@storefront-api/lib/util'
+import loadCustomFilters from '@storefront-api/default-catalog/helper/loadCustomFilters'
+import ProcessorFactory from '@storefront-api/default-catalog/processor/factory'
+
+import { Router } from 'express'
+import { elasticsearch, SearchQuery, ElasticsearchQueryConfig } from 'storefront-query-builder'
+import bodybuilder from 'bodybuilder'
+import get from 'lodash/get'
+
+const buildQuery = async ({ config, value }) => {
+  const customFilters = await loadCustomFilters(config)
+
+  const query = new SearchQuery()
+    .applyFilter({ key: 'mapUrl', value })
+    .applyFilter({ key: 'activeDateRange', value: '' })
+
+  return elasticsearch.buildQueryBodyFromSearchQuery({
+    config: config as ElasticsearchQueryConfig,
+    queryChain: bodybuilder(),
+    searchQuery: query,
+    customFilters
+  })
+}
+
+const getIndexNamesByTypes = ({ indexName, config }) => {
+  return get(config, 'urlModule.map.searchedEntities', [])
+    .map(entity => `${indexName}_${entity}`)
+}
+
+const addResultTypeByIndexName = ({ result, indexName }) => {
+  const type = result._index.replace(new RegExp(`^(${indexName}_)|(_[^_]*)$`, 'g'), '')
+  result._type = type
+  return result
+}
+
+const checkFieldValueEquality = ({ config, result, value }) => {
+  /**
+   * Checks result equality because ES can return record even if searched
+   * value is not EXACLY what we want (check `match_phrase` in ES docs).
+   */
+  return get(config, 'urlModule.map.searchedFields', [])
+    .some(f => result._source[f] === value)
+}
+
+export default ({ config }: ExtensionAPIFunctionParameter): Router => {
+  const router = Router()
+
+  router.post('/map', async (req, res) => {
+    const { url, excludeFields, includeFields } = req.body
+    if (!url) {
+      return apiStatus(res, 'Missing url', 500)
+    }
+
+    const indexName = getCurrentStoreView(getCurrentStoreCode(req)).elasticsearch.index
+    const index = getIndexNamesByTypes({ indexName, config })
+    const body = await buildQuery({ value: url, config })
+    const esQuery = {
+      index,
+      _source_includes: includeFields ? includeFields.concat(get(config, 'urlModule.map.includeFields', [])) : [],
+      _source_excludes: excludeFields ? excludeFields.concat(get(config, 'urlModule.map.excludeFields', [])) : [],
+      body
+    }
+
+    try {
+      const esResponse = await getElasticClient(config).search(esQuery)
+      let result = get(esResponse, 'body.hits.hits[0]', null)
+
+      if (result && checkFieldValueEquality({ config, result, value: url })) {
+        result = addResultTypeByIndexName({ result, indexName })
+
+        const factory = new ProcessorFactory(config)
+        let resultProcessor = factory.getAdapter(result._type, indexName, req, res)
+        if (!resultProcessor) {
+          resultProcessor = factory.getAdapter('default', indexName, req, res)
+        }
+
+        resultProcessor
+          .process(esResponse.body.hits.hits, null)
+          .then(pResult => {
+            pResult = pResult.map(h => Object.assign(h, { _score: h._score }))
+            return res.json(pResult[0])
+          }).catch((err) => {
+            console.error(err)
+            return res.json()
+          })
+      } else {
+        return res.json(null)
+      }
+    } catch (err) {
+      console.error(err)
+      return apiStatus(res, err.message, 500)
+    }
+  })
+
+  return router
+}


### PR DESCRIPTION
* Cache catalog-attribute request in thread to save Redis requests
* Improve loading of custom-filters to save IO interactions
* Wait for async _cacheStorageHandler in catalog requests
* Add new `/api/icmaa-url/map` endpoint based on `storefront-query-builder`
  * Add `mapUrl` api-search-query filter
  * Add FPC caching to new URL mapper

We need to switch to the new URL mapper in the VSF and add the new `mapUrl` api-search-query filter in the API: https://github.com/icmaa/shop-workspace/commit/c1ca6181b0ba4494e7c0785e89035f79dde7874b

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-247458

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
