### PR TITLE
Add custom cache-invalidation endpoints /w reasonable forwarding

### DIFF
--- a/src/modules/icmaa-cms/package.json
+++ b/src/modules/icmaa-cms/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "commander": "^6.2.1",
     "marked": "^2.0.5",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^3.2.1",
     "qs": "^6.9.1",
     "storyblok-js-client": "^2.0.0",
     "yaml": "^1.10.0"

--- a/src/modules/icmaa/index.ts
+++ b/src/modules/icmaa/index.ts
@@ -4,7 +4,7 @@ import { StorefrontApiModule, registerExtensions } from '@storefront-api/lib/mod
 import { StorefrontApiContext } from '@storefront-api/lib/module/types'
 import registerLogger from './logger'
 import url from './url'
-import invalidate from './invalidate'
+import { invalidate, invalidateAll } from './invalidate'
 import warmup from './warmup'
 
 // Import custom middlewares before the first route,
@@ -26,7 +26,9 @@ export const IcmaaModule: StorefrontApiModule = new StorefrontApiModule({
 
     app.use('/api/icmaa-url', url({ config, db }))
 
-    app.get('/api/invalidate/all', invalidate)
+    app.use('/api/icmaa-invalidate', invalidate)
+    app.get('/api/icmaa-invalidate/all', invalidateAll)
+
     app.get('/_ah/warmup', warmup)
   }
 })

--- a/src/modules/icmaa/invalidate.ts
+++ b/src/modules/icmaa/invalidate.ts
@@ -1,12 +1,87 @@
 import config from 'config'
+import fetch from 'node-fetch'
 import { RequestHandler } from 'express'
-import { apiStatus } from '@storefront-api/lib/util'
 import Logger from '@storefront-api/lib/logger'
+import cache from '@storefront-api/lib/cache-instance'
+import { apiStatus } from '@storefront-api/lib/util'
 import { ioRedis } from './helpers/redis'
 
-const router: RequestHandler = async (req, res) => {
+export const invalidate: RequestHandler = async (req, res) => {
   if (config.get('server.useOutputCache')) {
-    if (req.query.key !== config.get('server.invalidateCacheKey')) {
+    if (req.query.tag && req.query.key) {
+      if (req.query.key !== config.get('server.invalidateCacheKey')) {
+        return apiStatus(res, 'Invalid cache-key', 400)
+      }
+    } else {
+      Logger.error('Invalid parameters for Clear cache request')
+      return apiStatus(res, 'Invalid parameters for Clear cache request', 400)
+    }
+
+    const subPromises = []
+
+    const availableCacheTags = config.get<string[]>('server.availableCacheTags')
+    let tags = req.query.tag === '*' ? availableCacheTags : (req.query.tag as string).split(',')
+
+    tags = tags.filter(tag => {
+      const validTag = availableCacheTags.indexOf(tag) >= 0 || availableCacheTags.find(t => tag.indexOf(t) === 0)
+      if (!validTag) Logger.error(`Invalid tag name ${tag}`)
+      return validTag
+    })
+
+    if (tags.length === 0) {
+      return apiStatus(res, 'No valid cache-tags', 400)
+    }
+
+    tags.forEach(tag => {
+      const invalidateTag = cache
+        .invalidate(tag)
+        .then(() => {
+          Logger.info(`Tags invalidated successfully for [${tag}]`)
+        })
+
+      subPromises.push(invalidateTag)
+    })
+
+    if (config.get<boolean>('server.invalidateCacheForwarding') && !req.query?.forwardedFrom) {
+      const forwardUrl = config.get<string>('server.invalidateCacheForwardUrl') + tags.join(',') + '&forwardedFrom=api'
+      const forward = fetch(forwardUrl, { compress: true })
+        .then(async r => {
+          if (r.headers.get('content-type') === 'text/html') {
+            return { statusCode: r.status, response: await r.text() }
+          }
+          return r.json()
+        })
+        .catch(err => {
+          Logger.error(`Forwarded cache request failed. Can't render repsonse for: ${forwardUrl}`, err)
+          throw Error('Forwarded cache request failed. Can\'t render repsonse for.')
+        })
+        .then(r => {
+          if (r.statusCode >= 400) {
+            Logger.error(`Forwarded cache request failed: ${forwardUrl}`, r)
+            throw Error('Forwarded cache request failed.')
+          }
+          Logger.info(`Forwarded cache request to: ${forwardUrl}`, r)
+        })
+
+      subPromises.push(forward)
+    }
+
+    return Promise.all(subPromises)
+      .then(() => {
+        return apiStatus(res, `Tags invalidated successfully [${req.query.tag}]`, 200)
+      })
+      .catch(error => {
+        Logger.error('Error during cache-bust:', error)
+        return apiStatus(res, `Error during cache-bust: ${error.message}`, 500)
+      })
+  }
+
+  return apiStatus(res, 'Output-cache is disabled', 200)
+}
+
+export const invalidateAll: RequestHandler = async (req, res) => {
+  if (config.get('server.useOutputCache')) {
+    if (req.query?.key !== config.get('server.invalidateCacheKey')) {
       return apiStatus(res, 'Invalid cache-key', 400)
     }
 
@@ -25,5 +100,3 @@ const router: RequestHandler = async (req, res) => {
 
   return apiStatus(res, 'Output-cache is disabled', 200)
 }
-
-export default router

--- a/yarn.lock
+++ b/yarn.lock
@@ -5020,6 +5020,11 @@ data-uri-to-buffer@1:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz#77163ea9c20d8641b4707e8f18abdf9a78f34835"
   integrity sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
+
 data-urls@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
@@ -6432,6 +6437,14 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.0.tgz#3ffb6395453e3f3efff850404f0a59b6747f5f41"
   integrity sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.4.tgz#e8c6567f80ad7fc22fd302e7dcb72bafde9c1717"
+  integrity sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
@@ -6671,6 +6684,13 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 formidable@^1.2.0:
   version "1.2.2"
@@ -10380,10 +10400,24 @@ node-addon-api@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
   integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.1.tgz#002177382810cfb77858857f69a3621a86c45f26"
+  integrity sha512-Ef3SPFtRWFCDyhvcwCSvacLpkwmYZcD57mmZzAsMiks9TpHpIghe32U9H06tMICnr+X7YCpzH7WvUlUoml2urA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -15158,6 +15192,11 @@ wcwidth@^1.0.0:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
+  integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
* Add custom endpoints `/api/icmaa-invalidate` and `/api/icmaa-invalidate-all` for API driven output-cache-invalidation using cache-forwarding to VSF
* Update `node-fetch` library for security-patch

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
