### PR TITLE
Always add cache-tags independant of output-cache

### DIFF
--- a/packages/default-catalog/api/catalog.ts
+++ b/packages/default-catalog/api/catalog.ts
@@ -148,7 +148,7 @@ export default ({ config }: ExtensionAPIFunctionParameter) => async function (re
             const tagsArray = []
             const categoryTagsArray = []
 
-            if (config.get<boolean>('server.useOutputCache') && cache) {
+            if (config.get<boolean>('server.useOutputCacheTagging')) {
               const tagPrefix = entityType[0].toUpperCase() // first letter of entity name: P, T, A ...
               tagsArray.push(entityType)
               _resBody.hits.hits.forEach(item => {


### PR DESCRIPTION
* This is in preparation to remove output-cache from application
* Also add support for cache-tags to be visible on URL endpoint and after caching in catalog endpoints

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
