### PR TITLE
Update `devcontainer.json` (#75)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,16 +11,14 @@
     "docker-compose.yml"
   ],
   "service": "app",
-  "workspaceFolder": "/var/www",
+  "workspaceFolder": "/workspace",
   "extensions": [
     "christian-kohler.npm-intellisense",
     "christian-kohler.path-intellisense",
     "dbaeumer.vscode-eslint",
     "dotjoshjohnson.xml",
-    "eamodio.gitlens",
     "esbenp.prettier-vscode",
     "mechatroner.rainbow-csv",
-    "ms-vscode.js-debug-nightly",
     "redhat.vscode-yaml",
     "ria.elastic",
     "visualstudioexptteam.vscodeintellicode",


### PR DESCRIPTION
* Change `workspaceFolder` setting as we mount the root of our repo into the `/workspace` folder of the dev-container to have all files of the repo available in the service we are attaching to – otherwise folders like `./.git` or `.vscode` according to its Docker image will be missing and VSCode isn't working propertly.
* This setting seemed to be ignored by GitHub Codespaces before.

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
