### PR TITLE
#267374 Add `genericSubcategories` filter to URL filter 

### DIFF
--- a/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
+++ b/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
@@ -6,11 +6,16 @@ const searchFields: string[] = config.get('urlModule.map.searchedFields') || []
 const filter: FilterInterface = {
   priority: 1,
   check: ({ attribute }) => attribute === 'mapUrl',
-  filter: ({ value, queryChain }) => {
+  filter ({ value, queryChain }) {
     if (!value) return queryChain
 
     searchFields.forEach(field => {
-      queryChain.orFilter('match_phrase', field, { query: value })
+      queryChain.orFilter('term', field, value)
+
+      const nestedSubcategoryQuery = this.bodybuilder()
+        .query('term', 'genericSubcategories.' + field, value)
+        .build()
+      queryChain.orFilter('nested', { path: 'genericSubcategories', ...nestedSubcategoryQuery })
     })
 
     // Filter in-active child-categories

--- a/src/modules/icmaa/url.ts
+++ b/src/modules/icmaa/url.ts
@@ -38,15 +38,6 @@ const addResultTypeByIndexName = ({ result, indexName }) => {
   return result
 }
 
-const checkFieldValueEquality = ({ config, result, value }) => {
-  /**
-   * Checks result equality because ES can return record even if searched
-   * value is not EXACLY what we want (check `match_phrase` in ES docs).
-   */
-  return get(config, 'urlModule.map.searchedFields', [])
-    .some(f => result._source[f] === value)
-}
-
 export default ({ config }: ExtensionAPIFunctionParameter): Router => {
   const router = Router()
 
@@ -102,6 +93,7 @@ export default ({ config }: ExtensionAPIFunctionParameter): Router => {
     const indexName = getCurrentStoreView(storeCode).elasticsearch.index
     const index = getIndexNamesByTypes({ indexName, config })
     const body = await buildQuery({ value: url, config })
+
     const esQuery = {
       index,
       _source_includes: includeFields ? includeFields.concat(get(config, 'urlModule.map.includeFields', [])) : [],
@@ -113,7 +105,7 @@ export default ({ config }: ExtensionAPIFunctionParameter): Router => {
       const esResponse = await getElasticClient(config).search(esQuery)
       let result = getHits(esResponse)[0]
 
-      if (result && checkFieldValueEquality({ config, result, value: url })) {
+      if (result) {
         result = addResultTypeByIndexName({ result, indexName })
 
         const factory = new ProcessorFactory(config)


### PR DESCRIPTION
* And use `term` instead of `match_phrase` for field matching (also remove `checkFieldValueEquality` then)
* We need to add `urlPath` to `urlModule.map.searchedFields` config (https://github.com/icmaa/shop-workspace/commit/0ec872cf71729bd97470e46b6c12e95d36819320)

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-267374

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
