### PR TITLE
#267374 Improvement for new `MapUrlFilter`

### DIFF
--- a/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
+++ b/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
@@ -10,12 +10,7 @@ const filter: FilterInterface = {
     if (!value) return queryChain
 
     searchFields.forEach(field => {
-      queryChain.orFilter('term', field, value)
-
-      const nestedSubcategoryQuery = this.bodybuilder()
-        .query('term', 'genericSubcategories.' + field, value)
-        .build()
-      queryChain.orFilter('nested', { path: 'genericSubcategories', ...nestedSubcategoryQuery })
+      queryChain.orFilter('term', field + '.keyword', value)
     })
 
     // Filter in-active child-categories
@@ -26,14 +21,14 @@ const filter: FilterInterface = {
             .filter('term', 'is_active', true)
             .filter('wildcard', '_index', { value: '*_category_*' })
         })
-        .orFilter('bool', isProductQueryChain => {
-          return isProductQueryChain.notFilter('wildcard', '_index', { value: '*_category_*' })
+        .orFilter('bool', noCategoryQueryChain => {
+          return noCategoryQueryChain.notFilter('wildcard', '_index', { value: '*_category_*' })
         })
         .filterMinimumShouldMatch(1)
     })
 
     queryChain
-      .filterMinimumShouldMatch(1)
+      .filterMinimumShouldMatch(1, true)
       .size(1)
 
     return queryChain


### PR DESCRIPTION
* Use `term` and fields keyword for exact matches
* Enforce the use of `filterMinimumShouldMatch`, even if its just one or-condition
* Remove nested subcategory query

This is related to https://github.com/icmaa/shop-workspace/commit/d604d4e77219b2d3e8016c39d7bed76ac1521c9b

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-267374

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
