### PR TITLE
Use `match_phrase` in `MapUrlFilter` for exact match /w default analyzer

### DIFF
--- a/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
+++ b/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
@@ -10,7 +10,7 @@ const filter: FilterInterface = {
     if (!value) return queryChain
 
     searchFields.forEach(field => {
-      queryChain.orFilter('term', field + '.keyword', value)
+      queryChain.orFilter('match_phrase', field, value)
     })
 
     // Filter in-active child-categories


### PR DESCRIPTION
## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-267374

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
