### PR TITLE
Release 2023-01-26

### DIFF
--- a/.github/workflows/build-sc.yml
+++ b/.github/workflows/build-sc.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - feature/*
       - master
       - master-*
       - develop

--- a/packages/default-catalog/api/catalog.ts
+++ b/packages/default-catalog/api/catalog.ts
@@ -70,14 +70,19 @@ export default ({ config }: ExtensionAPIFunctionParameter) => async function (re
   if (urlSegments.length < 2) { throw new Error('No index name given in the URL. Please do use following URL format: /api/catalog/<index_name>/<entity_type>_search') } else {
     indexName = urlSegments[1]
 
-    if (urlSegments.length > 2) { entityType = urlSegments[2] }
+    try {
+      if (urlSegments.length > 2) { entityType = urlSegments[2] }
 
-    if (config.get<string[]>('elasticsearch.indices').indexOf(indexName) < 0) {
-      throw new Error('Invalid / inaccessible index name given in the URL. Please do use following URL format: /api/catalog/<index_name>/_search')
-    }
+      if (config.get<string[]>('elasticsearch.indices').indexOf(indexName) < 0) {
+        throw new Error('Invalid / inaccessible index name given in the URL. Please do use following URL format: /api/catalog/<index_name>/_search')
+      }
 
-    if (urlSegments[urlSegments.length - 1].indexOf('_search') !== 0) {
-      throw new Error('Please do use following URL format: /api/catalog/<index_name>/_search')
+      if (urlSegments[urlSegments.length - 1].indexOf('_search') !== 0) {
+        throw new Error('Please do use following URL format: /api/catalog/<index_name>/_search')
+      }
+    } catch (err) {
+      apiError(res, err)
+      return
     }
   }
 

--- a/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
+++ b/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
@@ -10,12 +10,7 @@ const filter: FilterInterface = {
     if (!value) return queryChain
 
     searchFields.forEach(field => {
-      queryChain.orFilter('term', field, value)
-
-      const nestedSubcategoryQuery = this.bodybuilder()
-        .query('term', 'genericSubcategories.' + field, value)
-        .build()
-      queryChain.orFilter('nested', { path: 'genericSubcategories', ...nestedSubcategoryQuery })
+      queryChain.orFilter('term', field + '.keyword', value)
     })
 
     // Filter in-active child-categories
@@ -26,14 +21,14 @@ const filter: FilterInterface = {
             .filter('term', 'is_active', true)
             .filter('wildcard', '_index', { value: '*_category_*' })
         })
-        .orFilter('bool', isProductQueryChain => {
-          return isProductQueryChain.notFilter('wildcard', '_index', { value: '*_category_*' })
+        .orFilter('bool', noCategoryQueryChain => {
+          return noCategoryQueryChain.notFilter('wildcard', '_index', { value: '*_category_*' })
         })
         .filterMinimumShouldMatch(1)
     })
 
     queryChain
-      .filterMinimumShouldMatch(1)
+      .filterMinimumShouldMatch(1, true)
       .size(1)
 
     return queryChain

--- a/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
+++ b/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
@@ -10,7 +10,7 @@ const filter: FilterInterface = {
     if (!value) return queryChain
 
     searchFields.forEach(field => {
-      queryChain.orFilter('term', field + '.keyword', value)
+      queryChain.orFilter('match_phrase', field, value)
     })
 
     // Filter in-active child-categories

--- a/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
+++ b/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/MapUrlFilter.ts
@@ -6,11 +6,16 @@ const searchFields: string[] = config.get('urlModule.map.searchedFields') || []
 const filter: FilterInterface = {
   priority: 1,
   check: ({ attribute }) => attribute === 'mapUrl',
-  filter: ({ value, queryChain }) => {
+  filter ({ value, queryChain }) {
     if (!value) return queryChain
 
     searchFields.forEach(field => {
-      queryChain.orFilter('match_phrase', field, { query: value })
+      queryChain.orFilter('term', field, value)
+
+      const nestedSubcategoryQuery = this.bodybuilder()
+        .query('term', 'genericSubcategories.' + field, value)
+        .build()
+      queryChain.orFilter('nested', { path: 'genericSubcategories', ...nestedSubcategoryQuery })
     })
 
     // Filter in-active child-categories

--- a/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/NullFilter.ts
+++ b/packages/default-catalog/api/extensions/icmaa-catalog/filter/catalog/NullFilter.ts
@@ -1,0 +1,19 @@
+import { FilterInterface } from 'storefront-query-builder'
+
+const filter: FilterInterface = {
+  priority: 1,
+  check: ({ operator }) => ['isNull', 'notNull'].includes(operator),
+  filter: ({ attribute, queryChain, operator }) => queryChain
+    .filter('bool', subQuery => {
+      if (operator === 'notNull') {
+        subQuery.filter('exists', attribute)
+      } else if (operator === 'isNull') {
+        subQuery.notFilter('exists', attribute)
+      }
+
+      return subQuery
+    }),
+  mutator: (value) => value[Object.keys(value)[0]]
+}
+
+export default filter

--- a/src/modules/icmaa/url.ts
+++ b/src/modules/icmaa/url.ts
@@ -38,15 +38,6 @@ const addResultTypeByIndexName = ({ result, indexName }) => {
   return result
 }
 
-const checkFieldValueEquality = ({ config, result, value }) => {
-  /**
-   * Checks result equality because ES can return record even if searched
-   * value is not EXACLY what we want (check `match_phrase` in ES docs).
-   */
-  return get(config, 'urlModule.map.searchedFields', [])
-    .some(f => result._source[f] === value)
-}
-
 export default ({ config }: ExtensionAPIFunctionParameter): Router => {
   const router = Router()
 
@@ -102,6 +93,7 @@ export default ({ config }: ExtensionAPIFunctionParameter): Router => {
     const indexName = getCurrentStoreView(storeCode).elasticsearch.index
     const index = getIndexNamesByTypes({ indexName, config })
     const body = await buildQuery({ value: url, config })
+
     const esQuery = {
       index,
       _source_includes: includeFields ? includeFields.concat(get(config, 'urlModule.map.includeFields', [])) : [],
@@ -113,7 +105,7 @@ export default ({ config }: ExtensionAPIFunctionParameter): Router => {
       const esResponse = await getElasticClient(config).search(esQuery)
       let result = getHits(esResponse)[0]
 
-      if (result && checkFieldValueEquality({ config, result, value: url })) {
+      if (result) {
         result = addResultTypeByIndexName({ result, indexName })
 
         const factory = new ProcessorFactory(config)


### PR DESCRIPTION
* Add `notNull` and `isNull` filter to query-builder (#80)  
* #267374 Add `genericSubcategories` filter to URL filter (#81)   
* #266589 Dont trigger build-job for SC in feature branches
* #267374 Improvement for new `MapUrlFilter` (#82) 
* Use `match_phrase` in `MapUrlFilter` for exact match /w default analyzer (#83)
* Prevent catalog API from crashing when error is dropped (#84)