### PR TITLE
Improve tax-processor of `magento1` platform

### DIFF
--- a/packages/default-catalog/processor/product.ts
+++ b/packages/default-catalog/processor/product.ts
@@ -49,9 +49,9 @@ class ProductProcessor extends ProcessorAbstract {
 
       // compact price fields
       if (this._req.query.response_format === 'compact') {
+        const fieldsToCompress = this._config.get('products.fieldsToCompress')
+        const fieldsToCompact = this._config.get('products.fieldsToCompact')
         resultSet[0] = resultSet[0].map((item) => {
-          const fieldsToCompress = this._config.get('products.fieldsToCompress')
-          const fieldsToCompact = this._config.get('products.fieldsToCompact')
           if (!item._source) { return item }
           if (item._source.configurable_children) {
             item._source.configurable_children = item._source.configurable_children.map((subItem) => {

--- a/packages/default-vsf/api/order.ts
+++ b/packages/default-vsf/api/order.ts
@@ -111,7 +111,7 @@ export default ({ config, db }) => resource({
     Logger.info(JSON.stringify(incomingOrder))
 
     for (const product of req.body.products) {
-      const key = config.tax.calculateServerSide ? { priceInclTax: product.priceInclTax, id: null, sku: null } : { price: product.price, id: null, sku: null }
+      const key = config.tax.calculateServerSide === true ? { priceInclTax: product.priceInclTax, id: null, sku: null } : { price: product.price, id: null, sku: null }
       if (config.tax.alwaysSyncPlatformPricesOver) {
         key.id = product.id
       } else {

--- a/packages/platform-magento1/tax.ts
+++ b/packages/platform-magento1/tax.ts
@@ -84,7 +84,7 @@ class TaxProxy extends AbstractTaxProxy {
     return new Promise((resolve, reject) => {
       this.applyTierPrices(productList, groupId)
 
-      if (this._config.get('tax.calculateServerSide')) {
+      if (this._config.get('tax.calculateServerSide') === true) {
         const client = es.getClient(this._config)
         const esQuery = es.adjustQuery({
           index: this._indexName,

--- a/packages/platform-magento2/tax.ts
+++ b/packages/platform-magento2/tax.ts
@@ -83,7 +83,7 @@ class TaxProxy extends AbstractTaxProxy {
     return new Promise((resolve, reject) => {
       this.applyTierPrices(productList, groupId)
 
-      if (this._storeConfigTax.calculateServerSide) {
+      if (this._storeConfigTax.calculateServerSide === true) {
         const client = es.getClient(this._config)
         const esQuery = es.adjustQuery({
           index: this._indexName,

--- a/src/modules/platform-magento1/src/tax.ts
+++ b/src/modules/platform-magento1/src/tax.ts
@@ -1,8 +1,5 @@
 import AbstractTaxProxy from '@storefront-api/platform-abstract/tax'
 import { calculateProductTax, checkIfTaxWithUserGroupIsActive, getUserGroupIdToUse } from '@storefront-api/lib/taxcalc'
-import TierHelper from '@storefront-api/lib/helpers/priceTiers'
-import bodybuilder from 'bodybuilder'
-import * as es from '@storefront-api/lib/elastic'
 
 class TaxProxy extends AbstractTaxProxy {
   private readonly _deprecatedPriceFieldsSupport: any
@@ -72,45 +69,16 @@ class TaxProxy extends AbstractTaxProxy {
     })
   }
 
-  public applyTierPrices (productList, groupId) {
-    if (this._config.get('usePriceTiers')) {
+  public process (productList: any[], groupId = null): Promise<any> {
+    return new Promise(resolve => {
       for (const item of productList) {
-        TierHelper(item._source, groupId)
+        if (!item._source?.price) break
+        const isActive = checkIfTaxWithUserGroupIsActive(this._storeConfigTax)
+        groupId = isActive ? getUserGroupIdToUse(this._userGroupId, this._storeConfigTax) : null
+        this.taxFor(item._source, groupId)
       }
-    }
-  }
 
-  public process (productList, groupId = null) {
-    return new Promise((resolve, reject) => {
-      this.applyTierPrices(productList, groupId)
-
-      if (this._config.get('tax.calculateServerSide')) {
-        const client = es.getClient(this._config)
-        const esQuery = es.adjustQuery({
-          index: this._indexName,
-          body: bodybuilder()
-        }, 'taxrule', this._config)
-
-        client.search(esQuery).then((result) => { // we're always trying to populate cache - when online
-          this._taxClasses = es.getHits(result).map(el => { return el._source })
-          for (const item of productList) {
-            const isActive = checkIfTaxWithUserGroupIsActive(this._storeConfigTax)
-            if (isActive) {
-              groupId = getUserGroupIdToUse(this._userGroupId, this._storeConfigTax)
-            } else {
-              groupId = null
-            }
-
-            this.taxFor(item._source, groupId)
-          }
-
-          resolve(productList)
-        }).catch(err => {
-          reject(err)
-        })
-      } else {
-        resolve(productList)
-      }
+      resolve(productList)
     })
   }
 }


### PR DESCRIPTION
* Don't query for tax-class agains ES
* Bugfix for `calculateServerSide` config-flag
* Don't render price in results if field is not in `_source_include`

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
