### PR TITLE
#275373 Aggregate attribute_metadata in response by `attributes_metadata` of products

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,18 +12,25 @@
   ],
   "service": "app",
   "workspaceFolder": "/workspace",
-  "extensions": [
-    "christian-kohler.npm-intellisense",
-    "christian-kohler.path-intellisense",
-    "dbaeumer.vscode-eslint",
-    "dotjoshjohnson.xml",
-    "esbenp.prettier-vscode",
-    "mechatroner.rainbow-csv",
-    "redhat.vscode-yaml",
-    "ria.elastic",
-    "visualstudioexptteam.vscodeintellicode",
-    "wix.vscode-import-cost",
-    "yzhang.markdown-all-in-one",
-    "ziyasal.vscode-open-in-github"
-  ]
+  "features": {
+    "ghcr.io/stuartleeks/dev-container-features/shell-history:0": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "christian-kohler.npm-intellisense",
+        "christian-kohler.path-intellisense",
+        "dbaeumer.vscode-eslint",
+        "dotjoshjohnson.xml",
+        "esbenp.prettier-vscode",
+        "mechatroner.rainbow-csv",
+        "redhat.vscode-yaml",
+        "ria.elastic",
+        "visualstudioexptteam.vscodeintellicode",
+        "wix.vscode-import-cost",
+        "yzhang.markdown-all-in-one",
+        "ziyasal.vscode-open-in-github"
+      ]
+    }
+  }
 }

--- a/docker/storefront-api/Dockerfile
+++ b/docker/storefront-api/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
     python3 make g++ ca-certificates \
     gcc libgcc libstdc++ linux-headers \
     vips-dev fftw-dev gcc g++ make libc6-compat \
-    bash curl wget git rsync
+    bash curl wget git rsync github-cli
 
 RUN yarn global add @icmaa/config-sync
 

--- a/src/modules/icmaa-catalog/api/mutator/attributeMetadata.ts
+++ b/src/modules/icmaa-catalog/api/mutator/attributeMetadata.ts
@@ -1,0 +1,52 @@
+export type Product = {
+  id: number,
+  attributes_metadata?: Attribute<Option>[],
+  [key: string]: unknown
+}
+
+export type Attribute<O> = {
+  id: number,
+  attribute_id: number,
+  attribute_code: string,
+  frontend_label: string,
+  default_frontend_label?: string,
+  frontend_input: string,
+  is_visible: boolean,
+  is_visible_on_front: boolean,
+  is_comparable: boolean,
+  options: O[],
+  entity_type_id: number,
+  is_user_defined: boolean
+}
+
+export type Option = {
+  label: string,
+  value: string | number,
+  sort_order: number
+}
+
+export function getAttributesFromProductsAttributesMetaData (items: { _source: Product }[])
+  : Record<string, Attribute<Option>> {
+  const attributes = {}
+  items.forEach(({ _source: item }) => {
+    if (!item.attributes_metadata) return
+    item.attributes_metadata.forEach(attr => {
+      if (!item[attr.attribute_code]) return
+      if (attributes[attr.attribute_code]) {
+        const options = [attributes[attr.attribute_code].options, ...attr.options]
+          .reduce((acc: Option[], option: Option): Option[] => {
+            const found = acc.find(o => o.value === option.value)
+            if (!found) acc.push(option)
+            return acc
+          }) as Option[]
+        attributes[attr.attribute_code].options = options
+      } else {
+        attributes[attr.attribute_code] = attr
+      }
+    })
+
+    delete item.attributes_metadata
+  })
+
+  return attributes
+}

--- a/src/modules/icmaa-catalog/api/mutator/attributeMetadata.ts
+++ b/src/modules/icmaa-catalog/api/mutator/attributeMetadata.ts
@@ -25,8 +25,7 @@ export type Option = {
   sort_order: number
 }
 
-export function getAttributesFromProductsAttributesMetaData (items: { _source: Product }[])
-  : Record<string, Attribute<Option>> {
+export function getAttributesFromProductsAttributesMetaData (items: { _source: Product }[]): Attribute<Option>[] {
   const attributes = {}
   items.forEach(({ _source: item }) => {
     if (!item.attributes_metadata) return
@@ -48,5 +47,5 @@ export function getAttributesFromProductsAttributesMetaData (items: { _source: P
     delete item.attributes_metadata
   })
 
-  return attributes
+  return Object.values(attributes)
 }


### PR DESCRIPTION
* This should safe a lot of payload inside the response, by aggregating the attribute-meta-data of the response into a separate array. This way each attribute- and option-data is only returned once and can be populated to the product again in the client.

Related to: https://github.com/icmaa/magento/pull/1476 & https://github.com/icmaa/catalog-packages/pull/10

## Related ticket
<!--  Put related Redmine issue number prefixed with `TCK-` which this PR is closing. For example TCK-12345 -->

TCK-275373

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
