### PR TITLE
Add options to Magento REST client to add custom headers

### DIFF
--- a/src/modules/magento1-vsbridge-client/lib/rest_client.ts
+++ b/src/modules/magento1-vsbridge-client/lib/rest_client.ts
@@ -7,6 +7,7 @@ export default (options) => {
 
   const serverUrl = options.url
   const auth = options.auth ? { auth: options.auth } : {}
+  const headers = options?.headers || {}
 
   const oauth = OAuth({
     consumer: {
@@ -58,7 +59,7 @@ export default (options) => {
       url: request_data.url,
       method: request_data.method,
       ...auth,
-      headers: { ...auth, ...authToken },
+      headers: { ...headers, ...auth, ...authToken },
       json: true,
       body: request_data.body
     }
@@ -77,7 +78,7 @@ export default (options) => {
         url: request_data.url,
         method: request_data.method,
         ...auth,
-        headers: { ...authToken },
+        headers: { ...headers, ...authToken },
         json: true,
         body: request_data.body,
         jar


### PR DESCRIPTION
* This is necessary to add the `X-Github-Token` header to authenticate between Gihtub Code-Spaces using the GH token
* Read more: https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#using-command-line-tools-and-rest-clients-to-access-ports

Related to:
* https://github.com/icmaa/shop-workspace/commit/2f3ac85cab83044195e383b2088ec5889039b049

## Checklist

- [x] I've made necessary changes in the configs repository `shop-workspace` (if needed)
- [x] I'm aware of depending changes in other repositories
